### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "i18next-resources-to-backend": "^1.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-i18next": "^14.1.0",
         "react-router-dom": "5.3.3",
         "styled-components": "^5.3.6",
         "ublob": "^1.0.1"
@@ -67,7 +68,6 @@
         "@types/node": "^18.11.18",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
-        "@types/react-i18next": "^8.1.0",
         "@types/react-router-dom": "^5.3.3",
         "@types/styled-components": "^5.1.26",
         "@typescript-eslint/eslint-plugin": "^5.49.0",


### PR DESCRIPTION
Hi @m-avagyan, 
There is missing react-i18next package in dependencies,
and @types/react-i18next (This is a stub types definition. react-i18next provides its own type definitions, so you do not need this installed.) [here](https://www.npmjs.com/package/@types/react-i18next)

Thanks 